### PR TITLE
feat: 세일 아이템 텍스트 최대 높이 설정 및  overflow 설정

### DIFF
--- a/lib/components/sale_item.dart
+++ b/lib/components/sale_item.dart
@@ -26,41 +26,43 @@ class SaleItemWidget extends StatelessWidget {
             Expanded(
               child: Container(
                 height: 70, // ItemContent 높이
-                padding: const EdgeInsets.symmetric(horizontal: 20),
+                padding: EdgeInsets.symmetric(horizontal: 20),
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
                       item.name,
-                      style: const TextStyle(
+                      style: TextStyle(
                         fontSize: 14,
                         fontWeight: FontWeight.w600,
                         color: primaryColor,
                       ),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
                     ),
                     Row(
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
                         Text(
                           '${item.discountRate}%',
-                          style: const TextStyle(
+                          style: TextStyle(
                             fontSize: 18.0,
                             color: lightRed,
                             fontWeight: FontWeight.w600,
                           ),
                         ),
-                        const SizedBox(width: 10),
+                        SizedBox(width: 10),
                         // 판매가
                         Text(
                           '${item.ncSellingPrice.toString()}원',
-                          style: const TextStyle(
+                          style: TextStyle(
                             fontSize: 18.0,
                             color: accentColor,
                             fontWeight: FontWeight.w600,
                           ),
                         ),
-                        const SizedBox(width: 10),
+                        SizedBox(width: 10),
                         Text(
                           '${item.originalPrice.toString()}원',
                           style: TextStyle(


### PR DESCRIPTION
## 📖 작업 배경 
- 세일 아이템의 상품명이 길어질 경우 레이아웃 깨짐 현상 발생
- `bottom overflowed by 20 pixels` 에러 발생

## 📖 구현 내용 
- Text 위젯에 maxLines와 overflow 속성 추가
 - maxLines: 2 (최대 2줄까지 표시)
 - overflow: TextOverflow.ellipsis (2줄 초과시 ... 처리)


## 💡 참고사항

## 🖼️ 스크린샷
<img width="300" alt="sale item overflow fix" src="https://github.com/user-attachments/assets/ee09b087-4e77-4586-8a88-a8cb82562783">
