### PR TITLE
feat: 데이터 프리페칭 구현으로 로딩 UX 개선

### DIFF
--- a/lib/screen/brand_product_screen.dart
+++ b/lib/screen/brand_product_screen.dart
@@ -7,11 +7,13 @@ import 'package:ncnc_flutter/repositories/brand_product_repository.dart';
 class BrandProductScreen extends StatefulWidget {
   final int brandId;
   final String brandName;
+  final Future<List<Product>>? prefetchedProducts;
 
   const BrandProductScreen({
     super.key,
     required this.brandId,
     required this.brandName,
+    this.prefetchedProducts,
   });
 
   @override
@@ -25,7 +27,7 @@ class _BrandProductScreenState extends State<BrandProductScreen> {
   @override
   void initState() {
     super.initState();
-    products = _repository.getBrandProducts(widget.brandId);
+    products = widget.prefetchedProducts ?? _repository.getBrandProducts(widget.brandId);
   }
 
   @override

--- a/lib/screen/brand_screen.dart
+++ b/lib/screen/brand_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:ncnc_flutter/components/custom_app_bar.dart';
 import 'package:ncnc_flutter/components/icon_card_grid.dart';
 import 'package:ncnc_flutter/models/brand_model.dart';
+import 'package:ncnc_flutter/repositories/brand_product_repository.dart';
 import 'package:ncnc_flutter/screen/brand_product_screen.dart';
 import 'package:ncnc_flutter/repositories/brand_repository.dart';
 
@@ -21,6 +22,7 @@ class BrandScreen extends StatefulWidget {
 
 class _BrandScreenState extends State<BrandScreen> {
   final _repository = BrandRepository();
+  final _productRepository = BrandProductRepository();
   late Future<List<Brand>> brands;
 
   @override
@@ -46,12 +48,14 @@ class _BrandScreenState extends State<BrandScreen> {
                     (brand) => (
                       imageUrl: brand.imageUrl,
                       title: brand.name,
-                      onTap: () {
+                      onTap: () async{
+                        final products = _productRepository.getBrandProducts(brand.id);
                         Navigator.of(context).push(
                           MaterialPageRoute(
                             builder: (context) => BrandProductScreen(
                               brandId: brand.id,
                               brandName: brand.name,
+                              prefetchedProducts: products,
                             ),
                           ),
                         );

--- a/lib/screen/brand_screen.dart
+++ b/lib/screen/brand_screen.dart
@@ -9,12 +9,19 @@ import 'package:ncnc_flutter/repositories/brand_repository.dart';
 class BrandScreen extends StatefulWidget {
   final int categoryId;
   final String categoryName;
+  final Future<List<Brand>>? prefetchedBrands;
+
 
   const BrandScreen({
     super.key,
     required this.categoryId,
     required this.categoryName,
+    this.prefetchedBrands,
   });
+
+  static Future<List<Brand>> prefetchData(int categoryId) {
+    return BrandRepository().getBrands(categoryId);
+  }
 
   @override
   State<BrandScreen> createState() => _BrandScreenState();
@@ -28,7 +35,7 @@ class _BrandScreenState extends State<BrandScreen> {
   @override
   void initState() {
     super.initState();
-    brands = _repository.getBrands(widget.categoryId);
+    brands = widget.prefetchedBrands ?? _repository.getBrands(widget.categoryId);
   }
 
   @override

--- a/lib/screen/home_screen.dart
+++ b/lib/screen/home_screen.dart
@@ -60,11 +60,13 @@ class _HomeScreenState extends State<HomeScreen> {
                               imageUrl: category.imageUrl,
                               title: category.name,
                               onTap: () {
+                                final brands = BrandScreen.prefetchData(category.id);
                                 Navigator.of(context).push(
                                   MaterialPageRoute(
                                     builder: (context) => BrandScreen(
                                       categoryId: category.id,
                                       categoryName: category.name,
+                                      prefetchedBrands: brands,
                                     ),
                                   ),
                                 );


### PR DESCRIPTION
📖 작업 배경

- 페이지 전환 시 UX 문제 발생

📖 구현 내용
 페이지 전환 시 데이터 프리페칭 구현

- BrandScreen: 브랜드 목록 데이터
- BrandProductScreen: 상품 목록 데이터

 
💡 참고사항

데이터 로딩과 페이지 전환 애니메이션을 병렬로 처리하여 UX 개선
페이지 전환이 완료되기 전에 데이터 로딩을 시작하여 대기 시간 단축